### PR TITLE
Added Red Hat software package installation instructions.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Install some additional texlive packages:
     sudo tlmgr install everypage background titlesec microtype upquote \
                        enumitem tcolorbox environ trimspaces siunitx
 
+On **Fedora/RHEL/CentOS**, run:
+sudo yum install texlive-xetex texlive-everypage texlive-background texlive-titlesec texlive-microtype texlive-upquote texlive-enumitem texlive-tcolorbox texlive-environ texlive-trimspaces texlive-siunitx
+
 On **Windows**:
 - Install TeXworks.
 - Install Source Tree, or your preferred Windows Git client.


### PR DESCRIPTION
Packages are required to be installed for building the Jackal user manual on various Red Hat Linux flavors.